### PR TITLE
SFIR-457 Fix the way we log errors on our application

### DIFF
--- a/src/common/helpers/metrics.js
+++ b/src/common/helpers/metrics.js
@@ -1,7 +1,7 @@
 import {
   createMetricsLogger,
-  Unit,
-  StorageResolution
+  StorageResolution,
+  Unit
 } from 'aws-embedded-metrics'
 import { config } from '../../config.js'
 import { createLogger } from './logging/logger.js'
@@ -20,8 +20,8 @@ const metricsCounter = async (metricName, value = 1) => {
       StorageResolution.Standard
     )
     await metricsLogger.flush()
-  } catch (error) {
-    createLogger().error(error, error.message)
+  } catch (err) {
+    createLogger().error(err, err.message)
   }
 }
 

--- a/src/common/helpers/sqs-client.js
+++ b/src/common/helpers/sqs-client.js
@@ -37,13 +37,8 @@ export const sqsClientPlugin = {
             server.logger.info(
               `Successfully processed message: ${message.MessageId}`
             )
-          } catch (error) {
-            server.logger.error('Failed to process message:', {
-              messageId: message.MessageId,
-              error: error.message,
-              stack: error.stack,
-              data: error.data
-            })
+          } catch (err) {
+            server.logger.error(err, 'Failed to process message')
           }
         },
         sqs: sqsClient,
@@ -56,17 +51,11 @@ export const sqsClientPlugin = {
       })
 
       app.on('error', (err) => {
-        server.logger.error('SQS Consumer error:', {
-          error: err.message,
-          stack: err.stack
-        })
+        server.logger.error(err, 'SQS Consumer error')
       })
 
       app.on('processing_error', (err) => {
-        server.logger.error('SQS Message processing error:', {
-          error: err.message,
-          stack: err.stack
-        })
+        server.logger.error(err, 'SQS Message processing error')
       })
 
       app.on('started', () => {

--- a/src/common/helpers/sqs-client.test.js
+++ b/src/common/helpers/sqs-client.test.js
@@ -166,10 +166,8 @@ describe('SQS Client', () => {
       await messageHandler(invalidMessage)
 
       expect(mockLogger.error).toHaveBeenCalledWith(
-        'Failed to process message:',
-        expect.objectContaining({
-          messageId: 'msg-1'
-        })
+        expect.any(Error),
+        'Failed to process message'
       )
     })
 
@@ -185,12 +183,7 @@ describe('SQS Client', () => {
       const error = new Error('Consumer error')
       errorHandler(error)
 
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        'SQS Consumer error:',
-        expect.objectContaining({
-          error: error.message
-        })
-      )
+      expect(mockLogger.error).toHaveBeenCalledWith(error, 'SQS Consumer error')
     })
 
     it('should handle processing errors', () => {
@@ -206,10 +199,8 @@ describe('SQS Client', () => {
       errorHandler(error)
 
       expect(mockLogger.error).toHaveBeenCalledWith(
-        'SQS Message processing error:',
-        expect.objectContaining({
-          error: error.message
-        })
+        error,
+        'SQS Message processing error'
       )
     })
 

--- a/src/common/helpers/sqs-message-processor.test.js
+++ b/src/common/helpers/sqs-message-processor.test.js
@@ -45,11 +45,8 @@ describe('SQS message processor', () => {
         'Invalid message format'
       )
       expect(mockLogger.error).toHaveBeenCalledWith(
-        expect.stringContaining('Error processing message'),
-        expect.objectContaining({
-          message,
-          error: expect.any(String)
-        })
+        expect.any(Error),
+        'Error processing message'
       )
     })
 
@@ -64,11 +61,8 @@ describe('SQS message processor', () => {
         'Error processing SQS message'
       )
       expect(mockLogger.error).toHaveBeenCalledWith(
-        expect.stringContaining('Error processing message'),
-        expect.objectContaining({
-          message,
-          error: expect.any(String)
-        })
+        expect.any(Error),
+        'Error processing message'
       )
     })
   })
@@ -140,9 +134,10 @@ describe('SQS message processor', () => {
         mockLogger
       )
       expect(mockLogger.error).toHaveBeenCalledWith(
-        expect.stringContaining(
-          'Failed to generate agreement SFI123456789-1 PDF. Error: Error: PDF generation failed'
-        )
+        expect.objectContaining({
+          message: 'PDF generation failed'
+        }),
+        'Failed to generate agreement SFI123456789-1 PDF from URL https://example.com/agreement/SFI123456789'
       )
     })
 

--- a/src/common/helpers/start-server.js
+++ b/src/common/helpers/start-server.js
@@ -14,11 +14,11 @@ async function startServer(options = {}) {
     )
 
     return server
-  } catch (error) {
+  } catch (err) {
     const logger = createLogger()
     logger.info('Server failed to start :(')
-    logger.error(error)
-    throw error
+    logger.error(err)
+    throw err
   }
 }
 

--- a/src/services/file-upload.js
+++ b/src/services/file-upload.js
@@ -57,7 +57,7 @@ async function upload(filePath, key, logger) {
       location: `s3://${bucket}/${key}`
     }
   } catch (error) {
-    logger.error(`Error uploading PDF ${filePath} to S3: ${error.message}`)
+    logger.error(error, `Error uploading PDF ${filePath} to S3`)
     throw error
   }
 }
@@ -95,10 +95,8 @@ export async function uploadPdf(
     }
 
     return uploadResult
-  } catch (error) {
-    logger.error(
-      `Error in PDF ${filename} generation and upload process: ${error.message}`
-    )
-    throw error
+  } catch (err) {
+    logger.error(err, `Error in PDF ${filename} generation and upload process`)
+    throw err
   }
 }

--- a/src/services/file-upload.test.js
+++ b/src/services/file-upload.test.js
@@ -116,7 +116,8 @@ describe('File Upload Service', () => {
       ).rejects.toThrow('Upload failed')
 
       expect(mockLogger.error).toHaveBeenCalledWith(
-        `Error in PDF ${testFilename} generation and upload process: Upload failed`
+        uploadError,
+        `Error in PDF ${testFilename} generation and upload process`
       )
     })
 
@@ -158,7 +159,10 @@ describe('File Upload Service', () => {
       ).rejects.toThrow('S3 bucket name is not configured')
 
       expect(mockLogger.error).toHaveBeenCalledWith(
-        `Error uploading PDF /some/path/agreement-456.pdf to S3: S3 bucket name is not configured`
+        expect.objectContaining({
+          message: 'S3 bucket name is not configured'
+        }),
+        `Error uploading PDF /some/path/agreement-456.pdf to S3`
       )
     })
   })

--- a/src/services/pdf-generator.js
+++ b/src/services/pdf-generator.js
@@ -97,17 +97,17 @@ export async function generatePdf(agreementData, filename, logger) {
     )
 
     return outputPath
-  } catch (error) {
-    logger.error(`Error generating PDF ${filename}: ${error}`)
+  } catch (err) {
+    logger.error(err, `Error generating PDF ${filename}`)
 
     if (browser) {
       try {
         await browser.close()
-      } catch (closeError) {
-        logger.error(`Error closing browser: ${closeError}`)
+      } catch (closeErr) {
+        logger.error(closeErr, `Error closing browser`)
       }
     }
 
-    throw error
+    throw err
   }
 }

--- a/src/services/pdf-generator.test.js
+++ b/src/services/pdf-generator.test.js
@@ -334,7 +334,10 @@ describe('pdf-generator', () => {
 
       // Should log error
       expect(mockLogger.error).toHaveBeenCalledWith(
-        'Error generating PDF test-nav-error.pdf: Error: Navigation failed'
+        expect.objectContaining({
+          message: 'Navigation failed'
+        }),
+        'Error generating PDF test-nav-error.pdf'
       )
     })
 
@@ -355,7 +358,10 @@ describe('pdf-generator', () => {
       ).rejects.toThrow('Form submission failed')
 
       expect(mockLogger.error).toHaveBeenCalledWith(
-        'Error generating PDF test-form-error.pdf: Error: Form submission failed'
+        expect.objectContaining({
+          message: 'Form submission failed'
+        }),
+        'Error generating PDF test-form-error.pdf'
       )
     })
 
@@ -374,7 +380,10 @@ describe('pdf-generator', () => {
       ).rejects.toThrow('PDF generation failed')
 
       expect(mockLogger.error).toHaveBeenCalledWith(
-        'Error generating PDF test-pdf-error.pdf: Error: PDF generation failed'
+        expect.objectContaining({
+          message: 'PDF generation failed'
+        }),
+        'Error generating PDF test-pdf-error.pdf'
       )
     })
 
@@ -395,7 +404,10 @@ describe('pdf-generator', () => {
       ).rejects.toThrow('Navigation timeout')
 
       expect(mockLogger.error).toHaveBeenCalledWith(
-        'Error generating PDF test-timeout.pdf: Error: Navigation timeout'
+        expect.objectContaining({
+          message: 'Navigation timeout'
+        }),
+        'Error generating PDF test-timeout.pdf'
       )
     })
 
@@ -418,7 +430,10 @@ describe('pdf-generator', () => {
 
       // Verify error was logged
       expect(mockLogger.error).toHaveBeenCalledWith(
-        'Error generating PDF test-cleanup.pdf: Error: Early error'
+        expect.objectContaining({
+          message: 'Early error'
+        }),
+        'Error generating PDF test-cleanup.pdf'
       )
     })
 
@@ -439,10 +454,16 @@ describe('pdf-generator', () => {
 
       // Should log both the main error and the browser close error
       expect(mockLogger.error).toHaveBeenCalledWith(
-        'Error generating PDF test-close-error.pdf: Error: Navigation failed'
+        expect.objectContaining({
+          message: 'Navigation failed'
+        }),
+        'Error generating PDF test-close-error.pdf'
       )
       expect(mockLogger.error).toHaveBeenCalledWith(
-        'Error closing browser: Error: Close failed'
+        expect.objectContaining({
+          message: 'Close failed'
+        }),
+        'Error closing browser'
       )
     })
   })


### PR DESCRIPTION
Pino expects the log methods to be called with `(obj, string)` not `(string, obj)`.

Also the CDP Support OpenSearch Log ingester is not consuming our bespoke error logs as they don't conform with the default keys they are consuming from the Pino method.

https://portal.cdp-int.defra.cloud/documentation/how-to/logging.md#current-streamlined-ecs-schema-on-cdp