### PR TITLE
SFIR-1172: use valid audit action and entity values in audit payload

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,9 @@ SNS_ENDPOINT=http://localhost:4566
 SNS_TOPIC_TYPE_AGREEMENT_STATUS_UPDATED=io.onsite.agreement.status.updated
 SNS_TOPIC_ARN_AGREEMENT_STATUS_UPDATED=arn:aws:sns:eu-west-2:000000000000:agreement_status_updated_fifo.fifo
 
+# FCP Audit configuration
+SNS_TOPIC_ARN_AUDIT=arn:aws:sns:eu-west-2:000000000000:fcp_audit_farming_grants_agreements_pdf
+
 # S3 bucket configuration
 S3_BUCKET=farming-grants-agreements-pdf-bucket
 S3_ENDPOINT=http://localhost:4568

--- a/src/common/helpers/audit-event.js
+++ b/src/common/helpers/audit-event.js
@@ -1,4 +1,4 @@
-import { audit } from '@defra/cdp-auditing'
+import { SNSClient, PublishCommand } from '@aws-sdk/client-sns'
 import { config } from '#~/config.js'
 
 export const AuditEvent = Object.freeze({
@@ -19,6 +19,19 @@ const eventTransactionCodes = {
 const eventActions = {
   [AuditEvent.PDF_UPLOADED_TO_S3]: 'created'
 }
+
+const snsClient = new SNSClient(
+  process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test'
+    ? {
+        region: config.get('aws.region'),
+        endpoint: config.get('aws.sns.endpoint'),
+        credentials: {
+          accessKeyId: config.get('aws.accessKeyId'),
+          secretAccessKey: config.get('aws.secretAccessKey')
+        }
+      }
+    : {}
+)
 
 /**
  * Builds the full audit payload for a PDF S3 operation.
@@ -56,11 +69,16 @@ const buildAuditPayload = (event, context = {}, status = 'success') => ({
 })
 
 /**
- * Records a PDF S3 operation audit event.
+ * Records a PDF S3 operation audit event by publishing to SNS.
  * @param {AuditEvent[keyof AuditEvent]} event
  * @param {{ agreementNumber: string, version: string|number, key: string, bucket: string, location?: string, correlationId?: string }} context
  * @param {'success'|'failure'} [status]
  */
-export const auditEvent = (event, context = {}, status = 'success') => {
-  audit(buildAuditPayload(event, context, status))
+export const auditEvent = async (event, context = {}, status = 'success') => {
+  await snsClient.send(
+    new PublishCommand({
+      TopicArn: config.get('aws.sns.topic.audit.arn'),
+      Message: JSON.stringify(buildAuditPayload(event, context, status))
+    })
+  )
 }

--- a/src/common/helpers/audit-event.js
+++ b/src/common/helpers/audit-event.js
@@ -15,9 +15,11 @@ const eventTransactionCodes = {
   [AuditEvent.PDF_UPLOADED_TO_S3]: '2307'
 }
 
-// Audit action for each event — must be one of: created, read, updated, deleted, submitted, accepted, rejected, withdrawn
-const eventActions = {
-  [AuditEvent.PDF_UPLOADED_TO_S3]: 'created'
+// Entities affected by each event — each entry is a function of context returning an array of { entity, action, id? }
+const eventEntities = {
+  [AuditEvent.PDF_UPLOADED_TO_S3]: (context) => [
+    { entity: 'agreement', action: 'created', id: context.agreementNumber }
+  ]
 }
 
 const snsClient = new SNSClient(
@@ -60,9 +62,7 @@ const buildAuditPayload = (event, context = {}, status = 'success') => ({
 
   audit: {
     eventtype: 'GrantsUploadAgreement',
-    action: eventActions[event],
-    entity: 'agreement',
-    entityid: context.agreementNumber,
+    entities: eventEntities[event](context),
     status,
     details: context
   }

--- a/src/common/helpers/audit-event.js
+++ b/src/common/helpers/audit-event.js
@@ -63,6 +63,11 @@ const buildAuditPayload = (event, context = {}, status = 'success') => ({
   audit: {
     eventtype: 'GrantsUploadAgreement',
     entities: eventEntities[event](context),
+    accounts: {
+      sbi: context.sbi,
+      frn: context.frn,
+      crn: context.crn
+    },
     status,
     details: context
   }

--- a/src/common/helpers/audit-event.js
+++ b/src/common/helpers/audit-event.js
@@ -15,6 +15,11 @@ const eventTransactionCodes = {
   [AuditEvent.PDF_UPLOADED_TO_S3]: '2307'
 }
 
+// Audit action for each event — must be one of: created, read, updated, deleted, submitted, accepted, rejected, withdrawn
+const eventActions = {
+  [AuditEvent.PDF_UPLOADED_TO_S3]: 'created'
+}
+
 /**
  * Builds the full audit payload for a PDF S3 operation.
  *
@@ -42,8 +47,8 @@ const buildAuditPayload = (event, context = {}, status = 'success') => ({
 
   audit: {
     eventtype: 'GrantsUploadAgreement',
-    action: event,
-    entity: 'Agreements',
+    action: eventActions[event],
+    entity: 'agreement',
     entityid: context.agreementNumber,
     status,
     details: context

--- a/src/common/helpers/audit-event.test.js
+++ b/src/common/helpers/audit-event.test.js
@@ -117,14 +117,43 @@ describe('auditEvent', () => {
       expect.objectContaining({
         audit: expect.objectContaining({
           eventtype: 'GrantsUploadAgreement',
-          action: 'PDF_UPLOADED_TO_S3',
-          entity: 'Agreements',
+          action: 'created',
+          entity: 'agreement',
           entityid: 'FPTT123456789',
           status: 'success',
           details: context
         })
       })
     )
+  })
+
+  test('audit.action for PDF_UPLOADED_TO_S3 is a valid action value', () => {
+    const validActions = [
+      'created',
+      'read',
+      'updated',
+      'deleted',
+      'submitted',
+      'accepted',
+      'rejected',
+      'withdrawn'
+    ]
+
+    auditEvent(AuditEvent.PDF_UPLOADED_TO_S3, {
+      agreementNumber: 'FPTT123456789'
+    })
+
+    const [[payload]] = audit.mock.calls
+    expect(validActions).toContain(payload.audit.action)
+  })
+
+  test('audit.entity is "agreement"', () => {
+    auditEvent(AuditEvent.PDF_UPLOADED_TO_S3, {
+      agreementNumber: 'FPTT123456789'
+    })
+
+    const [[payload]] = audit.mock.calls
+    expect(payload.audit.entity).toBe('agreement')
   })
 
   test('passes failure status through to the audit payload', () => {

--- a/src/common/helpers/audit-event.test.js
+++ b/src/common/helpers/audit-event.test.js
@@ -191,6 +191,36 @@ describe('auditEvent', () => {
     }
   })
 
+  test('audit.accounts is always present', async () => {
+    await auditEvent(AuditEvent.PDF_UPLOADED_TO_S3, {
+      agreementNumber: 'FPTT123456789'
+    })
+
+    const [command] = mockSnsClientSend.mock.calls[0]
+    const payload = JSON.parse(command.Message)
+    expect(payload.audit.accounts).toBeDefined()
+    expect(typeof payload.audit.accounts).toBe('object')
+  })
+
+  test('audit.accounts is populated from known context fields', async () => {
+    const context = {
+      agreementNumber: 'FPTT123456789',
+      sbi: '123456789',
+      frn: '9876543210',
+      crn: 'crn-001'
+    }
+
+    await auditEvent(AuditEvent.PDF_UPLOADED_TO_S3, context)
+
+    const [command] = mockSnsClientSend.mock.calls[0]
+    const payload = JSON.parse(command.Message)
+    expect(payload.audit.accounts).toEqual({
+      sbi: '123456789',
+      frn: '9876543210',
+      crn: 'crn-001'
+    })
+  })
+
   test('passes failure status through to the published payload', async () => {
     await auditEvent(AuditEvent.PDF_UPLOADED_TO_S3, {}, 'failure')
 

--- a/src/common/helpers/audit-event.test.js
+++ b/src/common/helpers/audit-event.test.js
@@ -1,10 +1,18 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 
+const mockSnsClientSend = vi.hoisted(() => vi.fn())
+
 const mockConfigGet = vi.hoisted(() =>
   vi.fn((key) => {
     const configMap = {
       cdpEnvironment: 'test',
-      serviceName: 'farming-grants-agreements-pdf'
+      serviceName: 'farming-grants-agreements-pdf',
+      'aws.region': 'eu-west-2',
+      'aws.sns.endpoint': 'http://localhost:4566',
+      'aws.accessKeyId': 'test',
+      'aws.secretAccessKey': 'test',
+      'aws.sns.topic.audit.arn':
+        'arn:aws:sns:eu-west-2:000000000000:fcp_audit_farming_grants_agreements_pdf'
     }
     return configMap[key]
   })
@@ -12,12 +20,24 @@ const mockConfigGet = vi.hoisted(() =>
 
 vi.mock('#~/config.js', () => ({ config: { get: mockConfigGet } }))
 
+vi.mock('@aws-sdk/client-sns', () => ({
+  SNSClient: class MockSNSClient {
+    send(command) {
+      return mockSnsClientSend(command)
+    }
+  },
+  PublishCommand: class MockPublishCommand {
+    constructor(params) {
+      Object.assign(this, params)
+    }
+  }
+}))
+
 describe('AuditEvent', () => {
   let AuditEvent
 
   beforeEach(async () => {
     vi.resetModules()
-    vi.doMock('@defra/cdp-auditing', () => ({ audit: vi.fn() }))
     ;({ AuditEvent } = await import('./audit-event.js'))
   })
 
@@ -43,15 +63,13 @@ describe('AuditEvent', () => {
 })
 
 describe('auditEvent', () => {
-  let audit
   let auditEvent
   let AuditEvent
 
   beforeEach(async () => {
     vi.resetModules()
-    vi.doMock('@defra/cdp-auditing', () => ({ audit: vi.fn() }))
+    mockSnsClientSend.mockResolvedValue({})
     ;({ auditEvent, AuditEvent } = await import('./audit-event.js'))
-    ;({ audit } = await import('@defra/cdp-auditing'))
   })
 
   afterEach(() => {
@@ -59,49 +77,19 @@ describe('auditEvent', () => {
     vi.clearAllMocks()
   })
 
-  test('calls audit with correct top-level fields for upload', () => {
-    const context = {
-      agreementNumber: 'FPTT123456789',
-      version: '1',
-      key: 'base/FPTT123456789/1/FPTT123456789-1.pdf',
-      bucket: 'test-bucket',
-      location: 's3://test-bucket/base/FPTT123456789/1/FPTT123456789-1.pdf',
-      correlationId: 'corr-xyz'
-    }
-
-    auditEvent(AuditEvent.PDF_UPLOADED_TO_S3, context)
-
-    expect(audit).toHaveBeenCalledWith(
-      expect.objectContaining({
-        correlationid: 'corr-xyz',
-        datetime: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/),
-        environment: 'test',
-        application: 'Grants',
-        component: 'farming-grants-agreements-pdf'
-      })
-    )
-  })
-
-  test('calls audit with correct security fields', () => {
-    auditEvent(AuditEvent.PDF_UPLOADED_TO_S3, {
+  test('publishes to SNS with correct TopicArn', async () => {
+    await auditEvent(AuditEvent.PDF_UPLOADED_TO_S3, {
       agreementNumber: 'FPTT123456789'
     })
 
-    expect(audit).toHaveBeenCalledWith(
-      expect.objectContaining({
-        security: expect.objectContaining({
-          pmccode: '0201',
-          details: expect.objectContaining({
-            transactioncode: '2307',
-            message: 'PDF document uploaded to S3',
-            additionalinfo: 'agreementNumber: FPTT123456789'
-          })
-        })
-      })
+    expect(mockSnsClientSend).toHaveBeenCalledOnce()
+    const [command] = mockSnsClientSend.mock.calls[0]
+    expect(command.TopicArn).toBe(
+      'arn:aws:sns:eu-west-2:000000000000:fcp_audit_farming_grants_agreements_pdf'
     )
   })
 
-  test('calls audit with correct audit fields for upload', () => {
+  test('publishes correct top-level fields for upload', async () => {
     const context = {
       agreementNumber: 'FPTT123456789',
       version: '1',
@@ -111,23 +99,64 @@ describe('auditEvent', () => {
       correlationId: 'corr-xyz'
     }
 
-    auditEvent(AuditEvent.PDF_UPLOADED_TO_S3, context)
+    await auditEvent(AuditEvent.PDF_UPLOADED_TO_S3, context)
 
-    expect(audit).toHaveBeenCalledWith(
-      expect.objectContaining({
-        audit: expect.objectContaining({
-          eventtype: 'GrantsUploadAgreement',
-          action: 'created',
-          entity: 'agreement',
-          entityid: 'FPTT123456789',
-          status: 'success',
-          details: context
-        })
-      })
-    )
+    const [command] = mockSnsClientSend.mock.calls[0]
+    const payload = JSON.parse(command.Message)
+
+    expect(payload).toMatchObject({
+      correlationid: 'corr-xyz',
+      datetime: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/),
+      environment: 'test',
+      application: 'Grants',
+      component: 'farming-grants-agreements-pdf'
+    })
   })
 
-  test('audit.action for PDF_UPLOADED_TO_S3 is a valid action value', () => {
+  test('publishes correct security fields', async () => {
+    await auditEvent(AuditEvent.PDF_UPLOADED_TO_S3, {
+      agreementNumber: 'FPTT123456789'
+    })
+
+    const [command] = mockSnsClientSend.mock.calls[0]
+    const payload = JSON.parse(command.Message)
+
+    expect(payload.security).toMatchObject({
+      pmccode: '0201',
+      details: {
+        transactioncode: '2307',
+        message: 'PDF document uploaded to S3',
+        additionalinfo: 'agreementNumber: FPTT123456789'
+      }
+    })
+  })
+
+  test('publishes correct audit fields for upload', async () => {
+    const context = {
+      agreementNumber: 'FPTT123456789',
+      version: '1',
+      key: 'base/FPTT123456789/1/FPTT123456789-1.pdf',
+      bucket: 'test-bucket',
+      location: 's3://test-bucket/base/FPTT123456789/1/FPTT123456789-1.pdf',
+      correlationId: 'corr-xyz'
+    }
+
+    await auditEvent(AuditEvent.PDF_UPLOADED_TO_S3, context)
+
+    const [command] = mockSnsClientSend.mock.calls[0]
+    const payload = JSON.parse(command.Message)
+
+    expect(payload.audit).toMatchObject({
+      eventtype: 'GrantsUploadAgreement',
+      action: 'created',
+      entity: 'agreement',
+      entityid: 'FPTT123456789',
+      status: 'success',
+      details: context
+    })
+  })
+
+  test('audit.action for PDF_UPLOADED_TO_S3 is a valid action value', async () => {
     const validActions = [
       'created',
       'read',
@@ -139,41 +168,39 @@ describe('auditEvent', () => {
       'withdrawn'
     ]
 
-    auditEvent(AuditEvent.PDF_UPLOADED_TO_S3, {
+    await auditEvent(AuditEvent.PDF_UPLOADED_TO_S3, {
       agreementNumber: 'FPTT123456789'
     })
 
-    const [[payload]] = audit.mock.calls
+    const [command] = mockSnsClientSend.mock.calls[0]
+    const payload = JSON.parse(command.Message)
     expect(validActions).toContain(payload.audit.action)
   })
 
-  test('audit.entity is "agreement"', () => {
-    auditEvent(AuditEvent.PDF_UPLOADED_TO_S3, {
+  test('audit.entity is "agreement"', async () => {
+    await auditEvent(AuditEvent.PDF_UPLOADED_TO_S3, {
       agreementNumber: 'FPTT123456789'
     })
 
-    const [[payload]] = audit.mock.calls
+    const [command] = mockSnsClientSend.mock.calls[0]
+    const payload = JSON.parse(command.Message)
     expect(payload.audit.entity).toBe('agreement')
   })
 
-  test('passes failure status through to the audit payload', () => {
-    auditEvent(AuditEvent.PDF_UPLOADED_TO_S3, {}, 'failure')
+  test('passes failure status through to the published payload', async () => {
+    await auditEvent(AuditEvent.PDF_UPLOADED_TO_S3, {}, 'failure')
 
-    expect(audit).toHaveBeenCalledWith(
-      expect.objectContaining({
-        audit: expect.objectContaining({ status: 'failure' })
-      })
-    )
+    const [command] = mockSnsClientSend.mock.calls[0]
+    const payload = JSON.parse(command.Message)
+    expect(payload.audit.status).toBe('failure')
   })
 
-  test('handles empty context gracefully', () => {
-    auditEvent(AuditEvent.PDF_UPLOADED_TO_S3)
+  test('handles empty context gracefully', async () => {
+    await auditEvent(AuditEvent.PDF_UPLOADED_TO_S3)
 
-    expect(audit).toHaveBeenCalledWith(
-      expect.objectContaining({
-        correlationid: undefined,
-        audit: expect.objectContaining({ entityid: undefined })
-      })
-    )
+    const [command] = mockSnsClientSend.mock.calls[0]
+    const payload = JSON.parse(command.Message)
+    expect(payload.correlationid).toBeUndefined()
+    expect(payload.audit.entityid).toBeUndefined()
   })
 })

--- a/src/common/helpers/audit-event.test.js
+++ b/src/common/helpers/audit-event.test.js
@@ -148,15 +148,15 @@ describe('auditEvent', () => {
 
     expect(payload.audit).toMatchObject({
       eventtype: 'GrantsUploadAgreement',
-      action: 'created',
-      entity: 'agreement',
-      entityid: 'FPTT123456789',
+      entities: [
+        { entity: 'agreement', action: 'created', id: 'FPTT123456789' }
+      ],
       status: 'success',
       details: context
     })
   })
 
-  test('audit.action for PDF_UPLOADED_TO_S3 is a valid action value', async () => {
+  test('audit.entities contains valid action values', async () => {
     const validActions = [
       'created',
       'read',
@@ -174,17 +174,21 @@ describe('auditEvent', () => {
 
     const [command] = mockSnsClientSend.mock.calls[0]
     const payload = JSON.parse(command.Message)
-    expect(validActions).toContain(payload.audit.action)
+    for (const entry of payload.audit.entities) {
+      expect(validActions).toContain(entry.action)
+    }
   })
 
-  test('audit.entity is "agreement"', async () => {
+  test('audit.entities entries each have an entity property', async () => {
     await auditEvent(AuditEvent.PDF_UPLOADED_TO_S3, {
       agreementNumber: 'FPTT123456789'
     })
 
     const [command] = mockSnsClientSend.mock.calls[0]
     const payload = JSON.parse(command.Message)
-    expect(payload.audit.entity).toBe('agreement')
+    for (const entry of payload.audit.entities) {
+      expect(typeof entry.entity).toBe('string')
+    }
   })
 
   test('passes failure status through to the published payload', async () => {
@@ -201,6 +205,6 @@ describe('auditEvent', () => {
     const [command] = mockSnsClientSend.mock.calls[0]
     const payload = JSON.parse(command.Message)
     expect(payload.correlationid).toBeUndefined()
-    expect(payload.audit.entityid).toBeUndefined()
+    expect(payload.audit.entities[0].id).toBeUndefined()
   })
 })

--- a/src/common/helpers/sqs-message-processor.js
+++ b/src/common/helpers/sqs-message-processor.js
@@ -14,6 +14,11 @@ const generateAndUploadPdf = async (data, logger) => {
   const version = data.version
   const endDate = data.endDate
   const correlationId = data.correlationId
+  const accounts = {
+    sbi: data.sbi,
+    frn: data.frn,
+    crn: data.crn
+  }
 
   // version is currently hardcoded until the version is passed from the API service
   const filename = `${agreementNumber}-${version}.pdf`
@@ -41,7 +46,7 @@ const generateAndUploadPdf = async (data, logger) => {
     agreementNumber,
     version,
     endDate,
-    correlationId,
+    { correlationId, accounts },
     logger
   )
   return pdfPath
@@ -54,7 +59,7 @@ const generateAndUploadPdf = async (data, logger) => {
  * @param {string} agreementNumber - The agreement number
  * @param {number} version - The agreement version
  * @param {Date|string} endDate - The agreement end date
- * @param {string} correlationId - The correlation ID from the originating SQS message
+ * @param {{ correlationId: string, accounts: object }} options - Correlation ID and known account identifiers
  * @param {import('@hapi/hapi').Server} logger - The logger instance
  * @returns {Promise<void>}
  */
@@ -64,7 +69,7 @@ const uploadPdfToS3 = async (
   agreementNumber,
   version,
   endDate,
-  correlationId,
+  { correlationId, accounts },
   logger
 ) => {
   try {
@@ -75,7 +80,7 @@ const uploadPdfToS3 = async (
       version,
       endDate,
       logger,
-      correlationId
+      { correlationId, accounts }
     )
     logger.info(
       `Agreement ${agreementNumber} PDF uploaded successfully (${uploadResult.success}) to S3`

--- a/src/common/helpers/sqs-message-processor.test.js
+++ b/src/common/helpers/sqs-message-processor.test.js
@@ -303,6 +303,19 @@ describe('SQS message processor', () => {
           'Agreement FPTT123456789 PDF uploaded successfully (true) to S3'
         )
       )
+
+      expect(mockUploadPdfFn).toHaveBeenCalledWith(
+        '/path/to/generated.pdf',
+        'FPTT123456789-1.pdf',
+        'FPTT123456789',
+        1,
+        '2027-12-31',
+        mockLogger,
+        {
+          correlationId: 'test-correlation-id',
+          accounts: { sbi: 'test-sbi', frn: 'test-frn', crn: undefined }
+        }
+      )
     })
 
     it('should handle PDF generation errors gracefully', async () => {

--- a/src/config.js
+++ b/src/config.js
@@ -190,6 +190,15 @@ const config = convict({
             default: 'io.onsite.agreement.status.updated',
             env: 'SNS_TOPIC_TYPE_AGREEMENT_STATUS_UPDATED'
           }
+        },
+        audit: {
+          arn: {
+            doc: 'AWS SNS Topic ARN for audit events',
+            format: String,
+            default:
+              'arn:aws:sns:eu-west-2:000000000000:fcp_audit_farming_grants_agreements_pdf',
+            env: 'SNS_TOPIC_ARN_AUDIT'
+          }
         }
       }
     },

--- a/src/contracts/consumer/agreements-to-pdf.contract.test.js
+++ b/src/contracts/consumer/agreements-to-pdf.contract.test.js
@@ -125,7 +125,10 @@ describe('receive an agreement accepted event', () => {
             1,
             '2025-09-31',
             mockLogger,
-            'mockCorrelationId'
+            {
+              correlationId: 'mockCorrelationId',
+              accounts: { sbi: undefined, frn: undefined, crn: undefined }
+            }
           )
         })
       )

--- a/src/services/file-upload.js
+++ b/src/services/file-upload.js
@@ -104,7 +104,7 @@ function calculateRetentionPeriod(endDate) {
  * @param {string} version Farming agreement document version
  * @param {Date|string} endDate Agreement end date
  * @param {Logger} logger Logger instance
- * @param {string} [correlationId] Correlation ID from the originating SQS message
+ * @param {{ correlationId?: string, accounts?: { sbi?: string, frn?: string, crn?: string } }} [options] Correlation ID and known account identifiers to include in the audit record
  * @returns {Promise<{success: boolean, bucket: *, key: *, etag: *, location: string}>}
  */
 export async function uploadPdf(
@@ -114,7 +114,7 @@ export async function uploadPdf(
   version,
   endDate,
   logger,
-  correlationId
+  { correlationId, accounts = {} } = {}
 ) {
   let uploadResult
 
@@ -131,7 +131,8 @@ export async function uploadPdf(
       key: uploadResult.key,
       bucket: uploadResult.bucket,
       location: uploadResult.location,
-      correlationId
+      correlationId,
+      ...accounts
     })
   } catch (err) {
     logger.error(err, `Error in PDF ${filename} generation and upload process`)


### PR DESCRIPTION
Map audit.action to a constrained set (created/read/updated/…) via eventActions rather than passing the raw event name, and correct audit.entity from 'Agreements' to 'agreement'.

https://eaflood.atlassian.net/wiki/spaces/FDM/pages/6491670800/Audit+Schema+Refinement