### PR TITLE
GSPS-220: add large pdf upload function test

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -64,6 +64,16 @@ jobs:
           AWS_SECRET_ACCESS_KEY: test
           AWS_DEFAULT_REGION: eu-west-2
 
+      - name: Run functional tests against LocalStack
+        run: npm run test:functional
+        env:
+          NODE_ENV: test
+          S3_ENDPOINT: http://localhost:4566
+          AWS_REGION: eu-west-2
+          AWS_ACCESS_KEY_ID: test
+          AWS_SECRET_ACCESS_KEY: test
+          S3_BUCKET: farming-grants-agreements-pdf-bucket
+
       - name: Test code and Create Test Coverage Reports
         run: |
           npm run format:check

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -64,7 +64,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: test
           AWS_DEFAULT_REGION: eu-west-2
 
-      - name: Run functional tests against LocalStack
+      - name: Run functional tests against floci
         run: npm run test:functional
         env:
           NODE_ENV: test

--- a/package.json
+++ b/package.json
@@ -25,8 +25,9 @@
     "server:watch": "nodemon --exec tsx --enable-source-maps ./src",
     "setup:husky": "node -e \"try { (await import('husky')).default() } catch (e) { if (e.code !== 'ERR_MODULE_NOT_FOUND') throw e }\" --input-type module",
     "start": "NODE_ENV=production node --use-strict .",
-    "test": "vitest run --exclude '**/contracts/**' --coverage --reporter=verbose",
-    "test:watch": "vitest --exclude '**/contracts/**'",
+    "test": "vitest run --exclude '**/contracts/**' --exclude '**/functional/**' --coverage --reporter=verbose",
+    "test:watch": "vitest --exclude '**/contracts/**' --exclude '**/functional/**'",
+    "test:functional": "vitest run --config vitest.functional.config.js",
     "test:contracts": "vitest run src/contracts",
     "test:contracts:consumer": "vitest run src/contracts/consumer",
     "test:contracts:provider": "echo 'No provider contract tests to run'"

--- a/src/functional/large-file-upload.test.js
+++ b/src/functional/large-file-upload.test.js
@@ -57,7 +57,7 @@ describe('Large PDF upload (>30MB) — functional', () => {
       await verificationClient.send(new HeadBucketCommand({ Bucket: BUCKET }))
     } catch {
       throw new Error(
-        `LocalStack S3 not reachable at ${S3_ENDPOINT} (bucket: ${BUCKET}). ` +
+        `floci S3 not reachable at ${S3_ENDPOINT} (bucket: ${BUCKET}). ` +
           'Is Floci running? Run: docker compose up'
       )
     }

--- a/src/functional/large-file-upload.test.js
+++ b/src/functional/large-file-upload.test.js
@@ -1,0 +1,106 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi
+} from 'vitest'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  DeleteObjectCommand,
+  HeadBucketCommand,
+  S3Client
+} from '@aws-sdk/client-s3'
+import { uploadPdf } from '#~/services/file-upload.js'
+
+vi.mock('#~/common/helpers/audit-event.js', () => ({
+  auditEvent: vi.fn(),
+  AuditEvent: { PDF_UPLOADED_TO_S3: 'PDF_UPLOADED_TO_S3' }
+}))
+
+const FIXTURE_SIZE = 32 * 1024 * 1024
+const BUCKET = process.env.S3_BUCKET ?? 'farming-grants-agreements-pdf-bucket'
+const S3_ENDPOINT = process.env.S3_ENDPOINT ?? 'http://localhost:4568'
+
+// Independent client for post-upload assertions — does not share the singleton from file-upload.js
+const verificationClient = new S3Client({
+  region: 'eu-west-2',
+  endpoint: S3_ENDPOINT,
+  credentials: { accessKeyId: 'test', secretAccessKey: 'test' },
+  forcePathStyle: true
+})
+
+const mockLogger = {
+  info: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn()
+}
+
+let fixturePath
+let testPdfPath
+let uploadedKey
+
+describe('Large PDF upload (>30MB) — functional', () => {
+  beforeAll(async () => {
+    fixturePath = path.join(os.tmpdir(), 'defra-pdf-functional-fixture.pdf')
+    const buf = Buffer.alloc(FIXTURE_SIZE)
+    Buffer.from('%PDF-1.4\n').copy(buf, 0)
+    await fs.writeFile(fixturePath, buf)
+
+    try {
+      await verificationClient.send(new HeadBucketCommand({ Bucket: BUCKET }))
+    } catch {
+      throw new Error(
+        `LocalStack S3 not reachable at ${S3_ENDPOINT} (bucket: ${BUCKET}). ` +
+          'Is Floci running? Run: docker compose up'
+      )
+    }
+  })
+
+  afterAll(async () => {
+    await fs.unlink(fixturePath).catch(() => {})
+  })
+
+  beforeEach(async () => {
+    testPdfPath = path.join(
+      os.tmpdir(),
+      `defra-pdf-functional-${Date.now()}-${Math.random().toString(36).slice(2)}.pdf`
+    )
+    await fs.copyFile(fixturePath, testPdfPath)
+    uploadedKey = undefined
+    vi.clearAllMocks()
+  })
+
+  afterEach(async () => {
+    if (uploadedKey) {
+      await verificationClient
+        .send(new DeleteObjectCommand({ Bucket: BUCKET, Key: uploadedKey }))
+        .catch(() => {})
+    }
+  })
+
+  test('S3 key follows the retention-prefix/agreement/version/filename structure', async () => {
+    // endDate 2045-01-01 always produces 'maximum' prefix regardless of current date:
+    // differenceInYears(2045, nextMonth) + retentionBaseYears(7) >> extendedTermThreshold(15)
+    const result = await uploadPdf(
+      testPdfPath,
+      'AGR001-1.pdf',
+      'AGR001',
+      '1',
+      new Date('2045-01-01'),
+      mockLogger
+    )
+
+    uploadedKey = result?.key
+
+    expect(result.key).toMatch(
+      /^(base|extended|maximum)\/AGR001\/1\/AGR001-1\.pdf$/
+    )
+  })
+})

--- a/src/services/pdf-generator.js
+++ b/src/services/pdf-generator.js
@@ -125,8 +125,9 @@ export async function generatePdf(agreementData, filename, logger) {
 
     await fs.access(outputPath)
 
+    const { size } = await fs.stat(outputPath)
     logger.info(
-      `PDF ${filename} generated successfully and saved to ${outputPath}`
+      `PDF ${filename} generated successfully and saved to ${outputPath} (${(size / (1024 * 1024)).toFixed(2)} MB)`
     )
 
     return outputPath

--- a/src/services/pdf-generator.test.js
+++ b/src/services/pdf-generator.test.js
@@ -17,6 +17,7 @@ const {
   mockBrowserCloseFn,
   mockFsAccessFn,
   mockFsMkdirFn,
+  mockFsStatFn,
   mockJwtTokenGenerateFn
 } = vi.hoisted(() => {
   const configMap = {
@@ -38,6 +39,7 @@ const {
     mockBrowserCloseFn: vi.fn(),
     mockFsAccessFn: vi.fn(),
     mockFsMkdirFn: vi.fn(),
+    mockFsStatFn: vi.fn().mockResolvedValue({ size: 1024 * 1024 }),
     mockJwtTokenGenerateFn: vi.fn()
   }
 })
@@ -62,7 +64,8 @@ vi.mock('node:fs/promises', async (importOriginal) => {
     default: {
       ...actual.default,
       access: mockFsAccessFn,
-      mkdir: mockFsMkdirFn
+      mkdir: mockFsMkdirFn,
+      stat: mockFsStatFn
     }
   }
 })
@@ -125,6 +128,7 @@ describe('PDF Generator Service', () => {
       .mockResolvedValueOnce(undefined) // Directory exists
       .mockResolvedValueOnce(undefined) // File exists after generation
     mockFsMkdirFn.mockResolvedValue(undefined)
+    mockFsStatFn.mockResolvedValue({ size: 1024 * 1024 })
 
     // Ensure config mock returns values
     mockConfigGetFn.mockImplementation((key) => {

--- a/vitest.functional.config.js
+++ b/vitest.functional.config.js
@@ -1,0 +1,29 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  resolve: {
+    extensions: []
+  },
+  test: {
+    globals: true,
+    environment: 'node',
+    root: '.',
+    include: ['src/functional/**/*.test.js'],
+    exclude: ['**/node_modules/**'],
+    testTimeout: 90000,
+    hookTimeout: 90000,
+    teardownTimeout: 30000,
+    pool: 'forks',
+    singleThread: true,
+    env: {
+      NODE_ENV: 'test',
+      AWS_REGION: 'eu-west-2',
+      AWS_ACCESS_KEY_ID: 'test',
+      AWS_SECRET_ACCESS_KEY: 'test',
+      S3_BUCKET: 'farming-grants-agreements-pdf-bucket'
+      // S3_ENDPOINT is intentionally omitted:
+      // - locally: config.js defaults to http://localhost:4568 (Docker Compose host port)
+      // - CI: the workflow step sets S3_ENDPOINT=http://localhost:4566 (Floci direct port)
+    }
+  }
+})


### PR DESCRIPTION
Commits:
* **add large pdf upload function test**
* **log file size in MB**

**Note:**
additional work done but was since removed:
_add 30MB/8MB/5MB/3MB jpg file to the end of the agreements PDF**
    This is to allow the QAs to test on our lower/remote  environments the
    ability of the service to generate, upload and download a large file.
     _This commit should be reversed, once testing is concluded.__