### PR TITLE
SFIR-1171 fix incorrect keys

### DIFF
--- a/src/common/helpers/audit-event.js
+++ b/src/common/helpers/audit-event.js
@@ -71,7 +71,7 @@ const buildAuditPayload = (
 ) => ({
   correlationid: context.correlationId,
   datetime: new Date().toISOString(),
-  environment: config.get('cdpEnvironment'),
+  environment: `cdp-${config.get('cdpEnvironment')}`,
   version: '0.1.0',
   application: 'Grants',
   component: config.get('serviceName'),

--- a/src/common/helpers/audit-event.js
+++ b/src/common/helpers/audit-event.js
@@ -16,10 +16,14 @@ const eventTransactionCodes = {
   [AuditEvent.PDF_UPLOADED_TO_S3]: '2307'
 }
 
-// Entities affected by each event — each entry is a function of context returning an array of { entity, action, id? }
+// Entities affected by each event — each entry is a function of context returning an array of { entity, action, entityId? }
 const eventEntities = {
   [AuditEvent.PDF_UPLOADED_TO_S3]: (context) => [
-    { entity: 'agreement', action: 'created', id: context.agreementNumber }
+    {
+      entity: 'agreement',
+      action: 'created',
+      entityId: context.agreementNumber
+    }
   ]
 }
 

--- a/src/common/helpers/audit-event.test.js
+++ b/src/common/helpers/audit-event.test.js
@@ -116,7 +116,7 @@ describe('auditEvent', () => {
     expect(payload).toMatchObject({
       correlationid: 'corr-xyz',
       datetime: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/),
-      environment: 'test',
+      environment: 'cdp-test',
       application: 'Grants',
       component: 'farming-grants-agreements-pdf'
     })

--- a/src/common/helpers/audit-event.test.js
+++ b/src/common/helpers/audit-event.test.js
@@ -158,7 +158,7 @@ describe('auditEvent', () => {
     expect(payload.audit).toMatchObject({
       eventtype: 'GrantsUploadAgreement',
       entities: [
-        { entity: 'agreement', action: 'created', id: 'FPTT123456789' }
+        { entity: 'agreement', action: 'created', entityId: 'FPTT123456789' }
       ],
       status: 'success',
       details: context
@@ -281,6 +281,6 @@ describe('auditEvent', () => {
     const [command] = mockSnsClientSend.mock.calls[0]
     const payload = JSON.parse(command.Message)
     expect(payload.correlationid).toBeUndefined()
-    expect(payload.audit.entities[0].id).toBeUndefined()
+    expect(payload.audit.entities[0].entityId).toBeUndefined()
   })
 })


### PR DESCRIPTION
* prefix CDP env name with 'cdp-' when auditing events

* replace 'id' with 'entityId' when auditing entities