### PR TITLE
FGP-1076: update our repositories to meet the new defra development standards

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,80 @@
+version: 2
+
+updates:
+  # Update npm packages
+  - package-ecosystem: npm
+    directory: /
+    open-pull-requests-limit: 10
+
+    # Group packages into shared PR
+    groups:
+      build:
+        patterns:
+          - 'autoprefixer'
+
+      lint:
+        patterns:
+          - 'prettier'
+          - 'stylelint'
+          - 'stylelint-*'
+
+      logging:
+        patterns:
+          - '*-pino'
+          - '*-pino-format'
+          - 'pino'
+          - 'pino-*'
+
+      tools:
+        patterns:
+          - 'husky'
+          - 'vitest'
+          - 'nodemon'
+          - 'npm-run-all'
+
+      types:
+        patterns:
+          - '@types/*'
+
+    ignore:
+      - dependency-name: 'eslint-*'
+      - dependency-name: 'eslint'
+
+    # Schedule run every Monday, local time
+    schedule:
+      interval: weekly
+      time: '10:30'
+      timezone: 'Europe/London'
+
+    versioning-strategy: increase
+
+    allow:
+      # Include direct package.json updates
+      - dependency-type: direct
+
+  # Update Docker base images
+  - package-ecosystem: docker
+    directory: /
+    open-pull-requests-limit: 10
+
+    # Group packages into shared PR
+    groups:
+      docker-images:
+        patterns:
+          - '*'
+
+    # Schedule run every Monday, local time
+    schedule:
+      interval: weekly
+      time: '10:30'
+      timezone: 'Europe/London'
+
+  # Update GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+
+    # Schedule run every Monday, local time
+    schedule:
+      interval: weekly
+      time: '10:30'
+      timezone: 'Europe/London'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,21 @@
+name: Dependency review
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  dependency-review:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,3 @@
 save-exact=true
+ignore-scripts=true
+min-release-age=7

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ ENV PORT=${PORT}
 EXPOSE ${PORT} ${PORT_DEBUG}
 
 COPY --chown=node:node package*.json ./
+COPY --chown=node:node .npmrc ./
 RUN npm install
 COPY --chown=node:node ./src ./src
 
@@ -69,6 +70,7 @@ ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 ENV TMP_PDF_FOLDER=/var/tmp/defra-pdf
 
 COPY --from=development /home/node/package*.json ./
+COPY --from=development /home/node/.npmrc ./
 COPY --from=development /home/node/src ./src/
 
 RUN npm ci --omit=dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ EXPOSE ${PORT} ${PORT_DEBUG}
 
 COPY --chown=node:node package*.json ./
 COPY --chown=node:node .npmrc ./
-RUN npm install
+RUN npm ci
 COPY --chown=node:node ./src ./src
 
 # Skip Puppeteer download since we use system Chromium


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FGP-1076

This PR brings farming-grants-agreements-pdf into line with the DEFRA Node.js, Dependabot and dependency-review development standards. It is config-only.

 Added
* .github/workflows/dependency-review.yml : runs actions/dependency-review-action on PRs to main to block newly introduced vulnerable dependencies before merge.
 -triggers on pull_request → main
 -permissions limited to contents: read, pull-requests: read
 -actions pinned to full commit SHAs per the CI standard (actions/checkout # v6.0.3, actions/dependency-review-action # v4.9.0)

* .github/dependabot.yml : activated the previously inert example.dependabot.yml as a live config and added the docker ecosystem, so Dependabot now covers:
 -npm (package.json)
 -docker (Dockerfile base images)
 -github-actions

* dependabot on a weekly schedule (Mon 10:30 Europe/London), with grouped PRs to reduce noise, using this repo's existing group definitions.

 Changed
* .npmrc : added the mandated npm security settings (kept existing save-exact=true):
 -ignore-scripts=true: block lifecycle-script execution (supply-chain protection)
 -min-release-age=7: refuse packages published <7 days ago (typosquat/takeover window)

* Dockerfile : copy .npmrc before npm install (development stage) and npm ci --omit=dev (production stage) so the image build enforces the same npm security controls (previously only package*.json was copied, so the repo-level .npmrc was not applied inside the image).

 Notes
* package.json and package-lock.json were already present (repeatable builds / npm ci support) — no change needed.
* No CI workflow fix was required. This repo's only npm lifecycle hook is postinstall → setup:husky (git hooks, not needed in CI). Puppeteer's Chromium download is also skipped by ignore-scripts, but that is harmless: the unit tests mock puppeteer, the functional test only uploads a pre-built PDF buffer to S3 (no browser launch), and the Docker image already installs system Chromium with PUPPETEER_SKIP_DOWNLOAD=1.
* Tests unaffected — full unit suite passes locally (168/168), lint and format:check clean.
* Enabling Dependabot alerts/security updates activated in GHAS.
* I have not activated CodeQL analysis in GHAS.
